### PR TITLE
Enable external traffic and switch to secure WebSocket

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=backend
+
+# Allow external traffic (required for ALB)
+server.address=0.0.0.0
+server.port=8080

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -346,13 +346,13 @@ export default function Table() {
   async function handleOnlineStart(){
     setMode(ONLINE);
     const uniqueID = generateUUID();
-    const newSocket = new WebSocket(`ws://localhost:8080/game/create/${uniqueID}`);
+    const newSocket = new WebSocket(`wss://localhost:8080/game/create/${uniqueID}`);
     newSocket.onopen = () =>{
       setSocket(newSocket);
       setGameState(ONLINE_WAIT_STATE);
       newSocket.send("updateRequest")
       setGameID(uniqueID);
-      console.log(`Websocket connection established at ws://localhost:8080/game/create/${uniqueID}`)
+      console.log(`Websocket connection established at wss://localhost:8080/game/create/${uniqueID}`)
     }
     newSocket.onmessage = (event) => {
       const gameUpdate = JSON.parse(event.data);
@@ -363,18 +363,18 @@ export default function Table() {
       setGameID(null);
       setMode(null);
       setSocket(null);
-      console.log(`Websocket connection at ws://localhost:8080/game/create/${uniqueID} has been closed.`)
+      console.log(`Websocket connection at wss://localhost:8080/game/create/${uniqueID} has been closed.`)
     }
   }
 
 
   async function handleOnlineJoin(){
     setMode(ONLINE);
-    const newSocket = new WebSocket(`ws://localhost:8080/game/join/${gameID}`)
+    const newSocket = new WebSocket(`wss://localhost:8080/game/join/${gameID}`)
     newSocket.onopen = () =>{
       setSocket(newSocket);
       newSocket.send("updateRequest")
-      console.log(`Websocket connection established at ws://localhost:8080/game/join/${gameID}`)
+      console.log(`Websocket connection established at wss://localhost:8080/game/join/${gameID}`)
     }
     newSocket.onmessage = (event) => {
       const gameUpdate = JSON.parse(event.data);
@@ -385,7 +385,7 @@ export default function Table() {
       setGameID(null);
       setMode(null);
       setSocket(null);
-      console.log(`Websocket connection at ws://localhost:8080/game/join/${gameID} has been closed.`)
+      console.log(`Websocket connection at wss://localhost:8080/game/join/${gameID} has been closed.`)
     }
   }
 


### PR DESCRIPTION
Configured backend to listen on 0.0.0.0:8080 for external access, required for ALB. Updated frontend WebSocket URLs from ws to wss for secure connections.